### PR TITLE
fix: #40 scrollbar background is white in dark mode in MacOS

### DIFF
--- a/src/renderer/src/styles/editor.scss
+++ b/src/renderer/src/styles/editor.scss
@@ -13,6 +13,9 @@
   --shadow: rgba(0, 0, 0, .3);
   --md-high-line: rgba(11, 18, 24, .5);
 }
+html.dark{
+  color-scheme: dark;
+}
 body{
   font-family: -apple-system, system-ui,ui-sans-serif, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, Noto Sans, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji;
   text-rendering: optimizeLegibility;


### PR DESCRIPTION
<img width="300" alt="image" src="https://github.com/1943time/bluestone/assets/131544788/085abf0e-4038-4683-a14a-1e7f1d08f935">
<img width="300" alt="image" src="https://github.com/1943time/bluestone/assets/131544788/72ae24a4-9539-462c-ad22-430d5dae4147">
